### PR TITLE
Various Improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,6 @@ config.mk: config.def.mk
 
 clean:
 	rm -f $(TARGET) box2d.a $(OBJS) $(BOX2D_OBJS)
+
+clean2:
+	rm -f $(TARGET) box2d.a $(OBJS)

--- a/draw.cpp
+++ b/draw.cpp
@@ -25,6 +25,7 @@ static draw_info draw_info_tbl[] = {
 	{ 1, 1.000f, 0.800f, 0.800f }, /* FCSIM_CCW_WHEEL */
 	{ 0, 0.000f, 0.000f, 1.000f }, /* FCSIM_ROD */
 	{ 0, 0.420f, 0.204f, 0.000f }, /* FCSIM_SOLID_ROD */
+	{ 0, 0.900f, 0.200f, 0.400f }, /* FCSIM_GOAL_RECT */
 };
 
 static void draw_rect(struct fcsim_block_def *block, float cr, float cg, float cb)

--- a/fcparse.cpp
+++ b/fcparse.cpp
@@ -12,6 +12,8 @@ const char *cur_str;
 yxml_ret_t cur_ret;
 struct fcsim_block_def *cur_block;
 int cur_id;
+int trash_int;
+double trash_double;
 
 static void next(void)
 {
@@ -137,6 +139,43 @@ void read_joints(int *joints)
 	next();
 }
 
+void toss_rotation_field(void)
+{
+	if (!strcmp(yxml.elem, "rotation"))
+	{
+		next();
+		trash_double = read_double();
+		expect_elem_end();
+		next();
+	}
+}
+void toss_tick_count(void)
+{
+	if (cur_ret == YXML_ELEMSTART) {
+		//is this second check necessary?
+		if (!strcmp(yxml.elem, "tickCount"))
+		{
+			next();
+			trash_double = read_double();
+			expect_elem_end();
+			next();
+		}
+	}
+}
+void toss_piece_count(void)
+{
+	if (cur_ret == YXML_ELEMSTART) {
+		//is this second check necessary?
+		if (!strcmp(yxml.elem, "pieceCount"))
+		{
+			next();
+			trash_double = read_double();
+			expect_elem_end();
+			next();
+		}
+	}
+}
+
 int block_type(const char *elem)
 {
 	if (!strcmp(elem, "StaticRectangle"))
@@ -157,6 +196,8 @@ int block_type(const char *elem)
 		return FCSIM_SOLID_ROD;
 	if (!strcmp(elem, "HollowRod"))
 		return FCSIM_ROD;
+	if (!strcmp(elem, "JointedDynamicRectangle"))
+		return FCSIM_GOAL_RECT;
 	return -1;
 }
 
@@ -191,8 +232,9 @@ static void read_level_blocks(void)
 {
 	expect_elem_start_exact("levelBlocks");
 	next();
-	while (cur_ret == YXML_ELEMSTART)
+	while (cur_ret == YXML_ELEMSTART) {
 		read_block();
+	}
 	expect_elem_end();
 	next();
 }
@@ -201,8 +243,9 @@ static void read_player_blocks(void)
 {
 	expect_elem_start_exact("playerBlocks");
 	next();
-	while (cur_ret == YXML_ELEMSTART)
+	while (cur_ret == YXML_ELEMSTART) {
 		read_block();
+	}
 	expect_elem_end();
 	next();
 }
@@ -213,6 +256,7 @@ static void read_start(void)
 	double w, h;
 	expect_elem_start_exact("start");
 	next();
+	toss_rotation_field();
 	read_position(&x, &y);
 	w = read_field_double("width");
 	h = read_field_double("height");
@@ -236,6 +280,7 @@ static void read_end(void)
 	double w, h;
 	expect_elem_start_exact("end");
 	next();
+	toss_rotation_field();
 	read_position(&x, &y);
 	w = read_field_double("width");
 	h = read_field_double("height");
@@ -261,6 +306,8 @@ static void read_level(void)
 	read_player_blocks();
 	read_start();
 	read_end();
+	toss_tick_count();
+	toss_piece_count();
 	expect_elem_end();
 	next();
 }

--- a/fcsim.cpp
+++ b/fcsim.cpp
@@ -111,6 +111,7 @@ static struct block_physics block_physics_tbl[] = {
 	{  1, 1.0, 0.7, 0.2,   1, -17,   0.0, 0.0 }, /* CCW_WHEEL */
 	{  0, 1.0, 0.7, 0.2,  16, -18, 0.009, 0.2 }, /* ROD */
 	{  0, 1.0, 0.7, 0.2, 256, -17, 0.009, 0.2 }, /* SOLID_ROD */
+	{  0, 1.0, 0.7, 0.2, 256, -17,   0.0, 0.0 }, /* GOAL_RECT */
 };
 
 static void generate_body(block *b)

--- a/get_xml.py
+++ b/get_xml.py
@@ -6,5 +6,5 @@ import xml.etree.ElementTree as et
 
 url = 'http://fantasticcontraption.com/retrieveLevel.php'
 
-resp = requests.post(url, data = {'id': sys.argv[1], 'loadDesign': 0})
+resp = requests.post(url, data = {'id': sys.argv[1], 'loadDesign': sys.argv[2]})
 print(resp.text)

--- a/main.cpp
+++ b/main.cpp
@@ -90,7 +90,7 @@ int main(void)
 	setup_draw();
 
 	int ticks = 0;
-	while (true) {
+	while (!glfwWindowShouldClose(window)) { 
 		draw_world(blocks, block_count);
 		glfwSwapBuffers(window);
 		glfwPollEvents();


### PR DESCRIPTION
* Makefile has a "clean2" option for only clearing fcsim compiled files, not touching box2d compiled files, for faster iteration
* get_xml.py now takes two arguments, one for the ID, one for whether its a design (0 for level, 1 for design)
* Now ignores rotation fields in the start/end, and tickCount and pieceCount fields from designs
* Goal Rects now work (mostly?)